### PR TITLE
Add build workflow for bookdown

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -1,0 +1,21 @@
+name: Build Book
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.3'
+      - name: Install bookdown
+        run: |
+          Rscript -e "install.packages('bookdown', repos='https://cloud.r-project.org')"
+      - name: Render book
+        run: |
+          Rscript -e "bookdown::render_book('index.Rmd')"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to render the book via `bookdown::render_book('index.Rmd')`

## Testing
- `Rscript -e "bookdown::render_book('index.Rmd')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684170a21718833292f2f4968d4c292a